### PR TITLE
use unroll for better performance

### DIFF
--- a/src/kernel.cpp
+++ b/src/kernel.cpp
@@ -21,6 +21,7 @@ int dp4a(const char4 a, const char4 b, const int c) { // 4-wide byte dot product
 kernel void kernel_double(global float* data) {
 	double x = (double)get_global_id(0);
 	double y = (double)get_local_id(0);
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<128u; i++) {
 		x = fma(y, x, y); // 2 operations
 		y = fma(x, y, x); // 2 operations
@@ -32,6 +33,7 @@ kernel void kernel_double(global float* data) {
 kernel void kernel_float(global float* data) {
 	float x = (float)get_global_id(0);
 	float y = (float)get_local_id(0);
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<512u; i++) {
 		x = fma(y, x, y); // 2 operations
 		y = fma(x, y, x); // 2 operations
@@ -43,6 +45,7 @@ kernel void kernel_float(global float* data) {
 kernel void kernel_half(global float* data) {
 	half2 x = (half2)((float)get_global_id(0), (float)get_local_id(0));
 	half2 y = (half2)((float)get_local_id(0), (float)get_global_id(0));
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<512u; i++) {
 		x = y*x+y; // 4 operations
 		y = x*y+x; // 4 operations
@@ -54,6 +57,7 @@ kernel void kernel_half(global float* data) {
 kernel void kernel_long(global float* data) {
 	long x = (long)get_global_id(0);
 	long y = (long)get_local_id(0);
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<8u; i++) {
 		x = y*x+y; // 2 operations
 		y = x*y+x; // 2 operations
@@ -64,6 +68,7 @@ kernel void kernel_long(global float* data) {
 kernel void kernel_int(global float* data) {
 	int x = get_global_id(0);
 	int y = get_local_id(0);
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<512u; i++) {
 		x = y*x+y; // 2 operations
 		y = x*y+x; // 2 operations
@@ -74,6 +79,7 @@ kernel void kernel_int(global float* data) {
 kernel void kernel_short(global float* data) {
 	short2 x = as_short2((uint)get_global_id(0));
 	short2 y = as_short2((uint)get_local_id(0));
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<128u; i++) {
 		x = y*x+y; // 4 operations
 		y = x*y+x; // 4 operations
@@ -84,6 +90,7 @@ kernel void kernel_short(global float* data) {
 kernel void kernel_char(global float* data) {
 	char4 x = as_char4((uint)get_global_id(0));
 	char4 y = as_char4((uint)get_local_id(0));
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<64u; i++) {
 		x = as_char4(dp4a(y, x, as_int(y))); // 8 operations
 		y = as_char4(dp4a(x, y, as_int(x))); // 8 operations
@@ -95,21 +102,25 @@ kernel void kernel_char(global float* data) {
 
 kernel void kernel_coalesced_write(global float* data) {
 	const uint n = get_global_id(0);
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<def_M; i++) data[i*def_N+n] = as_float(n); // coalesced write
 }
 kernel void kernel_coalesced_read(global float* data) {
 	const uint n = get_global_id(0);
 	float x = 0.0f;
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<def_M; i++) x += data[i*def_N+n]; // coalesced read
 	data[n] = x;
 }
 kernel void kernel_misaligned_write(global float* data) {
 	const uint n = get_global_id(0);
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<def_M; i++) data[n*def_M+i] = as_float(n); // misaligned write
 }
 kernel void kernel_misaligned_read(global float* data) {
 	const uint n = get_global_id(0);
 	float x = 0.0f;
+	__attribute__((opencl_unroll_hint)) 
 	for(uint i=0u; i<def_M; i++) x += data[n*def_M+i]; // misaligned read
 	data[n] = x;
 }


### PR DESCRIPTION
When I apply this benchmark for a mali gpu g78ae, I get the result like FP32 compute 0.051 TFLOPs/s
FP16 compute 0.102 TFLOPs/s
However, what I can get from datasheet is that it could have 100GFLOPS for FP32. Then we have two ways to make the benchmark result right. One is add more fma (like 16) in the for loop and multiply it when do the math. The other is unroll the loop with this attribute.
Both will help reach the performance limit.
FP32 compute 0.102 TFLOPs/s
FP16 compute 0.204 TFLOPs/s